### PR TITLE
Passes fail on clean install

### DIFF
--- a/__tests__/utils/app/importExports.test.ts
+++ b/__tests__/utils/app/importExports.test.ts
@@ -86,6 +86,7 @@ describe('cleanData Functions', () => {
       expect(isLatestExportFormat(obj)).toBe(true);
       expect(obj).toEqual({
         version: 4,
+        savedTemplates: [],
         history: [
           {
             id: 1,
@@ -141,6 +142,7 @@ describe('cleanData Functions', () => {
       expect(isLatestExportFormat(obj)).toBe(true);
       expect(obj).toEqual({
         version: 4,
+        savedTemplates: [],
         history: [
           {
             id: '1',


### PR DESCRIPTION
Export formatting seen in `utils\app\importExport.ts` includes `savedTemplates: []`, but this is not accounted for in the default unit tests.

On fresh installation, running the unit tests with `npm test` results in two failing tests as a result.

Updated the test cases to account for this formatting change to allow the unit tests to pass by default

